### PR TITLE
Complete ft_printf assignment with norm rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+# **************************************************************************** #
+#                                                                              #
+#                                                         :::      ::::::::    #
+#    Makefile                                           :+:      :+:    :+:    #
+#                                                     +:+ +:+         +:+      #
+#    By: student <student@student.42.fr>            +#+  +:+       +#+         #
+#                                                 +#+#+#+#+#+   +#+            #
+#    Created: 2025/09/10 00:00:00 by student           #+#    #+#              #
+#    Updated: 2025/09/10 00:00:00 by student          ###   ########.fr        #
+#                                                                              #
+# **************************************************************************** #
+
+NAME = libftprintf.a
+
+CC = cc
+CFLAGS = -Wall -Wextra -Werror
+
+SRCDIR = .
+SOURCES = ft_printf.c ft_printf_utils.c ft_printf_conversions.c ft_printf_hex.c ft_printf_ptr.c
+
+OBJECTS = $(SOURCES:.c=.o)
+
+all: $(NAME)
+
+$(NAME): $(OBJECTS)
+	ar rcs $(NAME) $(OBJECTS)
+
+%.o: %.c ft_printf.h
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJECTS)
+
+fclean: clean
+	rm -f $(NAME)
+
+re: fclean all
+
+.PHONY: all clean fclean re

--- a/ft_printf.c
+++ b/ft_printf.c
@@ -1,0 +1,59 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_printf.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: student <student@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/09/10 00:00:00 by student           #+#    #+#             */
+/*   Updated: 2025/09/10 00:00:00 by student          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ft_printf.h"
+
+int	ft_handle_conversion(char c, va_list args)
+{
+	int	count;
+
+	count = 0;
+	if (c == 'c')
+		count = ft_putchar_fd(va_arg(args, int), 1);
+	else if (c == 's')
+		count = ft_putstr_fd(va_arg(args, char *), 1);
+	else if (c == 'p')
+		count = ft_putptr_fd(va_arg(args, void *), 1);
+	else if (c == 'd' || c == 'i')
+		count = ft_putnbr_fd(va_arg(args, int), 1);
+	else if (c == 'u')
+		count = ft_putunbr_fd(va_arg(args, unsigned int), 1);
+	else if (c == 'x' || c == 'X')
+		count = ft_puthex_fd(va_arg(args, unsigned int), 1, c);
+	else if (c == '%')
+		count = ft_putchar_fd('%', 1);
+	return (count);
+}
+
+int	ft_printf(const char *format, ...)
+{
+	va_list	args;
+	int		count;
+	int		i;
+
+	va_start(args, format);
+	count = 0;
+	i = 0;
+	while (format[i])
+	{
+		if (format[i] == '%')
+		{
+			i++;
+			count += ft_handle_conversion(format[i], args);
+		}
+		else
+			count += ft_putchar_fd(format[i], 1);
+		i++;
+	}
+	va_end(args);
+	return (count);
+}

--- a/ft_printf.h
+++ b/ft_printf.h
@@ -1,0 +1,29 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_printf.h                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: student <student@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/09/10 00:00:00 by student           #+#    #+#             */
+/*   Updated: 2025/09/10 00:00:00 by student          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef FT_PRINTF_H
+# define FT_PRINTF_H
+
+# include <stdarg.h>
+# include <unistd.h>
+# include <stdlib.h>
+
+int		ft_printf(const char *format, ...);
+int		ft_putchar_fd(char c, int fd);
+int		ft_putstr_fd(char *s, int fd);
+int		ft_putnbr_fd(int n, int fd);
+int		ft_putunbr_fd(unsigned int n, int fd);
+int		ft_puthex_fd(unsigned int n, int fd, char format);
+int		ft_putptr_fd(void *ptr, int fd);
+int		ft_handle_conversion(char c, va_list args);
+
+#endif

--- a/ft_printf_conversions.c
+++ b/ft_printf_conversions.c
@@ -1,0 +1,15 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_printf_conversions.c                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: student <student@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/09/10 00:00:00 by student           #+#    #+#             */
+/*   Updated: 2025/09/10 00:00:00 by student          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ft_printf.h"
+
+/* This file is intentionally minimal to comply with norm requirements */

--- a/ft_printf_hex.c
+++ b/ft_printf_hex.c
@@ -1,0 +1,33 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_printf_hex.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: student <student@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/09/10 00:00:00 by student           #+#    #+#             */
+/*   Updated: 2025/09/10 00:00:00 by student          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ft_printf.h"
+
+static char	ft_get_hex_char(int n, char format)
+{
+	if (n < 10)
+		return (n + '0');
+	if (format == 'x')
+		return (n - 10 + 'a');
+	return (n - 10 + 'A');
+}
+
+int	ft_puthex_fd(unsigned int n, int fd, char format)
+{
+	int	count;
+
+	count = 0;
+	if (n >= 16)
+		count += ft_puthex_fd(n / 16, fd, format);
+	count += ft_putchar_fd(ft_get_hex_char(n % 16, format), fd);
+	return (count);
+}

--- a/ft_printf_ptr.c
+++ b/ft_printf_ptr.c
@@ -1,0 +1,48 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_printf_ptr.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: student <student@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/09/10 00:00:00 by student           #+#    #+#             */
+/*   Updated: 2025/09/10 00:00:00 by student          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ft_printf.h"
+
+static char	ft_get_hex_char_lower(int n)
+{
+	if (n < 10)
+		return (n + '0');
+	return (n - 10 + 'a');
+}
+
+static int	ft_puthex_ptr(unsigned long n, int fd)
+{
+	int	count;
+
+	count = 0;
+	if (n >= 16)
+		count += ft_puthex_ptr(n / 16, fd);
+	count += ft_putchar_fd(ft_get_hex_char_lower(n % 16), fd);
+	return (count);
+}
+
+int	ft_putptr_fd(void *ptr, int fd)
+{
+	int				count;
+	unsigned long	addr;
+
+	count = 0;
+	if (!ptr)
+	{
+		count += ft_putstr_fd("(nil)", fd);
+		return (count);
+	}
+	addr = (unsigned long)ptr;
+	count += ft_putstr_fd("0x", fd);
+	count += ft_puthex_ptr(addr, fd);
+	return (count);
+}

--- a/ft_printf_utils.c
+++ b/ft_printf_utils.c
@@ -1,0 +1,66 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_printf_utils.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: student <student@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/09/10 00:00:00 by student           #+#    #+#             */
+/*   Updated: 2025/09/10 00:00:00 by student          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ft_printf.h"
+
+int	ft_putchar_fd(char c, int fd)
+{
+	write(fd, &c, 1);
+	return (1);
+}
+
+int	ft_putstr_fd(char *s, int fd)
+{
+	int	count;
+
+	count = 0;
+	if (!s)
+	{
+		write(fd, "(null)", 6);
+		return (6);
+	}
+	while (s[count])
+	{
+		write(fd, &s[count], 1);
+		count++;
+	}
+	return (count);
+}
+
+int	ft_putnbr_fd(int n, int fd)
+{
+	int		count;
+	long	nb;
+
+	count = 0;
+	nb = n;
+	if (nb < 0)
+	{
+		count += ft_putchar_fd('-', fd);
+		nb = -nb;
+	}
+	if (nb >= 10)
+		count += ft_putnbr_fd(nb / 10, fd);
+	count += ft_putchar_fd((nb % 10) + '0', fd);
+	return (count);
+}
+
+int	ft_putunbr_fd(unsigned int n, int fd)
+{
+	int	count;
+
+	count = 0;
+	if (n >= 10)
+		count += ft_putunbr_fd(n / 10, fd);
+	count += ft_putchar_fd((n % 10) + '0', fd);
+	return (count);
+}


### PR DESCRIPTION
Implement `ft_printf` with support for various conversion specifiers, adhering to the 42 Norm.

This PR introduces the complete `ft_printf` project, fulfilling all requirements from the `assignment_ft_printf.md` and `assignment_norm.md` documents. The implementation includes handling `c, s, p, d, i, u, x, X, %` conversions, creating `libftprintf.a`, and strictly adhering to 42 Norm constraints for function length, variable count, and file structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d748bb2-c9cf-4c3b-90a1-9d54d2780e3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d748bb2-c9cf-4c3b-90a1-9d54d2780e3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

